### PR TITLE
Support for rc builds

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,8 @@
 import org.opensearch.gradle.test.RestIntegTestTask
 
+import java.util.regex.Matcher
+import java.util.regex.Pattern
+
 apply plugin: 'java'
 apply plugin: 'idea'
 apply plugin: 'opensearch.opensearchplugin'
@@ -43,8 +46,32 @@ buildscript {
 
     ext {
 
-        plugin_version = version
-        opensearch_version = plugin_version.replaceAll(/\.[0-9]+(|-SNAPSHOT)$/, "")
+        // Four {digit(s)} concatenated with a "." followed by -rc{digit(s)}
+        // Examples: 1.0.0.1-rc2, 2.10.4.0-rc5
+        // Group (3) refers to the last .{digit{(s)} pattern (this is what we want to remove for OpS version)
+        final Pattern RC_pattern = Pattern.compile(/([0-9](\.[0-9]+){2})(\.[0-9]+)(-rc[0-9]+)$/)
+
+        // Four {digit(s)} concatenated with a "." followed by null or -SNAPSHOT
+        // Examples: 1.0.0.1, 2.10.4.0-SNAPSHOT
+        // Group (3) refers to the last .{digit{(s)} pattern (this is what we want to remove for OpS version)
+        final Pattern OTHER_pattern = Pattern.compile(/([0-9](\.[0-9]+){2})(\.[0-9]+)(|-SNAPSHOT)$/)
+
+        String opensearch_version
+        String plugin_version = version
+
+        Matcher rc_matcher = RC_pattern.matcher(plugin_version)
+        Matcher other_matcher = OTHER_pattern.matcher(plugin_version)
+
+        println("Identifing version of OpenSearch based on plugin version")
+        if (rc_matcher.find()) {
+            opensearch_version = rc_matcher.group(1) + rc_matcher.group(4)
+        } else if (other_matcher.find()) {
+            opensearch_version = other_matcher.group(1)
+        } else {
+            throw new InvalidUserDataException("Invalid plugin version [" + version + "] in gradle.properties file.")
+        }
+        println("- OpenSearch version: " + opensearch_version)
+        println("- Prometheus exporter plugin version: " + plugin_version)
 
         versions = [
                 "opensearch": opensearch_version,


### PR DESCRIPTION
This commit introduces support for release candidate builds.

This means we can now build and publish plugin releases for OpenSearch-rc releases.

More specifically, we now support the following plugin versioning schemas:

**Release candidates schema: A.B.C.D-rcE**
  Examples:

    Plugin ver.         Required OpenSearch ver.
    -----------------   -----------------
    1.0.0.1-rc2         1.0.0-rc2
    2.10.4.0-rc5        2.10.4-rc5

Regular (and legacy) schema: A.B.C.D[-SNAPSHOT]
  Examples:

    Plugin ver.         Required OpenSearch ver.
    -----------------   -----------------
    1.0.0.1             1.0.0
    2.10.4.0-SNAPSHOT   2.10.4

If the plugin version does not follow supported schemas then an exception is thrown and build process is terminated.

Closes: #51

Signed-off-by: Lukáš Vlček <lukas.vlcek@aiven.io>