### PR TITLE
Upgrade to OpenSearch 2.0.0-rc1

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 #group = org.opensearch.plugin.prometheus
 
-version = 1.3.2.0
+version = 2.0.0.0-rc1
 
 pluginName = prometheus-exporter
 pluginClassname = org.opensearch.plugin.prometheus.PrometheusExporterPlugin

--- a/src/main/java/org/compuscene/metrics/prometheus/PrometheusMetricsCollector.java
+++ b/src/main/java/org/compuscene/metrics/prometheus/PrometheusMetricsCollector.java
@@ -316,16 +316,9 @@ public class PrometheusMetricsCollector {
             catalog.setNodeGauge(nodeInfo,"indices_completion_size_bytes", idx.getCompletion().getSizeInBytes());
 
             catalog.setNodeGauge(nodeInfo,"indices_segments_number", idx.getSegments().getCount());
-            catalog.setNodeGauge(nodeInfo,"indices_segments_memory_bytes", idx.getSegments().getMemoryInBytes(), "all");
             catalog.setNodeGauge(nodeInfo,"indices_segments_memory_bytes", idx.getSegments().getBitsetMemoryInBytes(), "bitset");
-            catalog.setNodeGauge(nodeInfo,"indices_segments_memory_bytes", idx.getSegments().getDocValuesMemoryInBytes(), "docvalues");
             catalog.setNodeGauge(nodeInfo,"indices_segments_memory_bytes", idx.getSegments().getIndexWriterMemoryInBytes(), "indexwriter");
-            catalog.setNodeGauge(nodeInfo,"indices_segments_memory_bytes", idx.getSegments().getNormsMemoryInBytes(), "norms");
-            catalog.setNodeGauge(nodeInfo,"indices_segments_memory_bytes", idx.getSegments().getStoredFieldsMemoryInBytes(), "storefields");
-            catalog.setNodeGauge(nodeInfo,"indices_segments_memory_bytes", idx.getSegments().getTermsMemoryInBytes(), "terms");
-            catalog.setNodeGauge(nodeInfo,"indices_segments_memory_bytes", idx.getSegments().getTermVectorsMemoryInBytes(), "termvectors");
             catalog.setNodeGauge(nodeInfo,"indices_segments_memory_bytes", idx.getSegments().getVersionMapMemoryInBytes(), "versionmap");
-            catalog.setNodeGauge(nodeInfo,"indices_segments_memory_bytes", idx.getSegments().getPointsMemoryInBytes(), "points");
 
             catalog.setNodeGauge(nodeInfo,"indices_suggest_current_number", idx.getSearch().getTotal().getSuggestCurrent());
             catalog.setNodeGauge(nodeInfo,"indices_suggest_count", idx.getSearch().getTotal().getSuggestCount());
@@ -535,16 +528,9 @@ public class PrometheusMetricsCollector {
         catalog.setClusterGauge("index_completion_size_bytes", idx.getCompletion().getSizeInBytes(), indexName, context);
 
         catalog.setClusterGauge("index_segments_number", idx.getSegments().getCount(), indexName, context);
-        catalog.setClusterGauge("index_segments_memory_bytes", idx.getSegments().getMemoryInBytes(), "all", indexName, context);
         catalog.setClusterGauge("index_segments_memory_bytes", idx.getSegments().getBitsetMemoryInBytes(), "bitset", indexName, context);
-        catalog.setClusterGauge("index_segments_memory_bytes", idx.getSegments().getDocValuesMemoryInBytes(), "docvalues", indexName, context);
         catalog.setClusterGauge("index_segments_memory_bytes", idx.getSegments().getIndexWriterMemoryInBytes(), "indexwriter", indexName, context);
-        catalog.setClusterGauge("index_segments_memory_bytes", idx.getSegments().getNormsMemoryInBytes(), "norms", indexName, context);
-        catalog.setClusterGauge("index_segments_memory_bytes", idx.getSegments().getStoredFieldsMemoryInBytes(), "storefields", indexName, context);
-        catalog.setClusterGauge("index_segments_memory_bytes", idx.getSegments().getTermsMemoryInBytes(), "terms", indexName, context);
-        catalog.setClusterGauge("index_segments_memory_bytes", idx.getSegments().getTermVectorsMemoryInBytes(), "termvectors", indexName, context);
         catalog.setClusterGauge("index_segments_memory_bytes", idx.getSegments().getVersionMapMemoryInBytes(), "versionmap", indexName, context);
-        catalog.setClusterGauge("index_segments_memory_bytes", idx.getSegments().getPointsMemoryInBytes(), "points", indexName, context);
 
         catalog.setClusterGauge("index_suggest_current_number", idx.getSearch().getTotal().getSuggestCurrent(), indexName, context);
         catalog.setClusterGauge("index_suggest_count", idx.getSearch().getTotal().getSuggestCount(), indexName, context);

--- a/src/yamlRestTest/resources/rest-api-spec/test/30_19_index_segments.yml
+++ b/src/yamlRestTest/resources/rest-api-spec/test/30_19_index_segments.yml
@@ -45,7 +45,7 @@
         \# \s TYPE \s opensearch_index_segments_memory_bytes \s gauge \n
         (
           opensearch_index_segments_memory_bytes\{
-              cluster="yamlRestTest",type="(all|bitset|docvalues|indexwriter|norms|storefields|terms|termvectors|versionmap|points)",index="twitter",context="(primaries|total)"
+              cluster="yamlRestTest",type="(bitset|indexwriter|versionmap)",index="twitter",context="(primaries|total)"
           ,\} \s+ \d+\.\d+ \n?
-        ){20}
+        ){6}
         .*/


### PR DESCRIPTION
**Breaking changes:**

The following metrics were dropped:

- `index_segments_memory_bytes`, label=`all`
- `index_segments_memory_bytes`, label=`docvalues`
- `index_segments_memory_bytes`, label=`norms`
- `index_segments_memory_bytes`, label=`storefields`
- `index_segments_memory_bytes`, label=`terms`
- `index_segments_memory_bytes`, label=`termvectors`
- `index_segments_memory_bytes`, label=`points`

See https://issues.apache.org/jira/browse/LUCENE-9387 for more details.

Closes: #53
Signed-off-by: Lukáš Vlček <lukas.vlcek@aiven.io>