### PR TITLE
Upgrade to OpenSearch 2.0.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -81,6 +81,7 @@ buildscript {
 
     repositories {
         mavenLocal()
+        maven { url "https://aws.oss.sonatype.org/content/repositories/releases" }
         maven { url "https://aws.oss.sonatype.org/content/repositories/snapshots" }
         mavenCentral()
         maven { url "https://plugins.gradle.org/m2/" }
@@ -94,6 +95,7 @@ buildscript {
 
 repositories {
     mavenLocal()
+    maven { url "https://aws.oss.sonatype.org/content/repositories/releases" }
     maven { url "https://aws.oss.sonatype.org/content/repositories/snapshots" }
     mavenCentral()
     maven { url "https://plugins.gradle.org/m2/" }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 #group = org.opensearch.plugin.prometheus
 
-version = 2.0.0.0-rc1
+version = 2.0.0.0
 
 pluginName = prometheus-exporter
 pluginClassname = org.opensearch.plugin.prometheus.PrometheusExporterPlugin


### PR DESCRIPTION
https://opensearch.org/blog/releases/2022/05/opensearch-2-0-is-now-available/
Signed-off-by: Lukáš Vlček <lukas.vlcek@aiven.io>