### PR TITLE
prepare release v2.0.1.0 for OpenSearch 2.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,15 +38,16 @@ This plugin was started as a fork of [Prometheus exporter for Elasticsearch®](h
 
 ## Compatibility Matrix
 
-| OpenSearch |      Plugin | Release date |
-|-----------:|------------:|-------------:|
-|      2.0.0 |     2.0.0.0 | May 27, 2022 |
-|  2.0.0-rc1 | 2.0.0.0-rc1 | May 19, 2022 |
-|      1.3.3 |     1.3.3.0 | Jun 15, 2022 |
-|      1.3.2 |     1.3.2.0 | May 10, 2022 |
-|      1.3.1 |     1.3.1.0 | Apr 08, 2022 |
-|      1.3.0 |     1.3.0.0 | Mar 22, 2022 |
-|   <= 1.2.4 |         (*) |          (*) |
+| OpenSearch |      Plugin |  Release date |
+|-----------:|------------:|--------------:|
+|      2.0.1 |     2.0.1.0 | June 17, 2022 |
+|      2.0.0 |     2.0.0.0 |  May 27, 2022 |
+|  2.0.0-rc1 | 2.0.0.0-rc1 |  May 19, 2022 |
+|      1.3.3 |     1.3.3.0 |  Jun 15, 2022 |
+|      1.3.2 |     1.3.2.0 |  May 10, 2022 |
+|      1.3.1 |     1.3.1.0 |  Apr 08, 2022 |
+|      1.3.0 |     1.3.0.0 |  Mar 22, 2022 |
+|   <= 1.2.4 |         (*) |           (*) |
 
 _(*) If you are looking for plugin releases supporting earlier (`<= 1.2.4`) OpenSearch versions please visit
 <https://github.com/aparo/opensearch-prometheus-exporter/releases>._
@@ -57,7 +58,7 @@ You need to install the plugin on every OpenSearch node that will be scraped by 
 
 To **install** the plugin:
 
-`./bin/opensearch-plugin install https://github.com/aiven/prometheus-exporter-plugin-for-opensearch/releases/download/2.0.0.0/prometheus-exporter-2.0.0.0.zip`
+`./bin/opensearch-plugin install https://github.com/aiven/prometheus-exporter-plugin-for-opensearch/releases/download/2.0.1.0/prometheus-exporter-2.0.1.0.zip`
 
 To **remove** the plugin.
 


### PR DESCRIPTION
i first wanted to contribute the actual version upgrade just to realise that this is all handled just based on the version number :)
so i thought i'd at least provide the README update.

i briefly tested that this compiles fine (& the tests run through):
```
$ ./gradlew build -Pversion=2.0.1.0

> Configure project :
Identifing version of OpenSearch based on plugin version
- OpenSearch version: 2.0.1
- Prometheus exporter plugin version: 2.0.1.0
=======================================
OpenSearch Build Hamster says Hello!
  Gradle Version        : 6.8.3
  OS Info               : Windows 10 10.0 (amd64)
  JDK Version           : 11 (Eclipse Adoptium JDK)
  JAVA_HOME             : [..]
  Random Testing Seed   : F83F4696E46B3A26
  In FIPS 140 mode      : false
=======================================

BUILD SUCCESSFUL in 1m 28s
29 actionable tasks: 27 executed, 2 up-to-date
```