### PR TITLE
chore: bump OpenSearch from 1.3.5 to 1.3.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ This plugin was started as a fork of [Prometheus exporter for Elasticsearch®](h
 
 | OpenSearch |  Plugin | Release date |
 |-----------:|--------:|-------------:|
+|      1.3.6 | 1.3.6.0 | Oct  7, 2022 |
 |      1.3.5 | 1.3.5.0 | Sep  5, 2022 |
 |      1.3.4 | 1.3.4.0 | Jul 15, 2022 |
 |      1.3.3 | 1.3.3.0 | Jun 15, 2022 |
@@ -57,7 +58,7 @@ You need to install the plugin on every OpenSearch node that will be scraped by 
 
 To **install** the plugin:
 
-`./bin/opensearch-plugin install https://github.com/aiven/prometheus-exporter-plugin-for-opensearch/releases/download/1.3.5.0/prometheus-exporter-1.3.5.0.zip`
+`./bin/opensearch-plugin install https://github.com/aiven/prometheus-exporter-plugin-for-opensearch/releases/download/1.3.6.0/prometheus-exporter-1.3.6.0.zip`
 
 To **remove** the plugin.
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 #group = org.opensearch.plugin.prometheus
 
-version = 1.3.5.0
+version = 1.3.6.0
 
 pluginName = prometheus-exporter
 pluginClassname = org.opensearch.plugin.prometheus.PrometheusExporterPlugin


### PR DESCRIPTION
https://github.com/opensearch-project/opensearch-build/blob/main/release-notes/opensearch-release-notes-1.3.6.md