### PR TITLE
Remove all grants from `plugin-security.policy`

### DIFF
--- a/src/main/plugin-metadata/plugin-security.policy
+++ b/src/main/plugin-metadata/plugin-security.policy
@@ -16,7 +16,5 @@
  */
 
 grant {
-    permission java.lang.RuntimePermission "accessClassInPackage.sun.misc";
-    permission java.lang.RuntimePermission "accessDeclaredMembers";
-    permission java.lang.reflect.ReflectPermission "suppressAccessChecks";
+    // No privileged operations are required, see #131
 };


### PR DESCRIPTION
We do not need any grants in `plugin-security.policy`. There is currently no PrivilegedAction block. Removal of grants simplify plugin installation a bit because no user confirmation is needed any longer.

This is not a breaking change because when plugins are installed from script then usually `-b` option is used anyway, which skips the confirmation step.

Closes: #131

Signed-off-by: Lukáš Vlček <lukas.vlcek@aiven.io>