### PR TITLE
enable GitHub dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,25 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    target-branch: v1.3
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    target-branch: mixin
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "gradle"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "gradle"
+    directory: "/"
+    target-branch: v1.3
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
this will (partially) automate dependency updates. dependabot will create PRs if a dependency can be updated automatically. see the [dependabot documentation][docs] for further information.

solves #149

note: as always with dependabot config there isn't any easy way to test this, so this is untested (it's actually the first time i'm setting it up for a gradle project! with other projects it worked fine so far).

[docs]: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates