### PR TITLE
Pre-upgrade the exporter to support OpenSearch 2.7.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 #group = org.opensearch.plugin.prometheus
 
-version = 2.6.0.0
+version = 2.7.0.0
 
 pluginName = prometheus-exporter
 pluginClassname = org.opensearch.plugin.prometheus.PrometheusExporterPlugin


### PR DESCRIPTION
OpenSearch 2.7.0 is set to release tomorrow, 25/4-2023. This pre-release PR is added to quickly push out a new version of the prometheus-exporter whenever 2.7.0 is released.