### PR TITLE
Upgrade to OpenSearch 2.18.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,10 +7,10 @@ version = 2.18.0.0
 opensearch_version =
 
 # A version of OpenSearch cluster to run BWC tests against
-BWCversion = 2.17.0
+BWCversion = 2.17.1
 
 # A version of plugin to deploy to BWC clusters
-BWCPluginVersion = 2.17.0.0
+BWCPluginVersion = 2.17.1.0
 
 pluginName = prometheus-exporter
 pluginClassname = org.opensearch.plugin.prometheus.PrometheusExporterPlugin

--- a/src/test/java/org/opensearch/plugin/bwc/PluginBackwardsCompatibilityIT.java
+++ b/src/test/java/org/opensearch/plugin/bwc/PluginBackwardsCompatibilityIT.java
@@ -34,8 +34,8 @@ import java.util.stream.Collectors;
  */
 public class PluginBackwardsCompatibilityIT extends OpenSearchRestTestCase {
 
-    public static final Version BWCVersion = Version.V_2_17_0;
-    public static final Version NewVersion = Version.V_2_17_1;
+    public static final Version BWCVersion = Version.V_2_17_1;
+    public static final Version NewVersion = Version.V_2_18_0;
 
     private static final ClusterType CLUSTER_TYPE = ClusterType.parse(System.getProperty("tests.rest.bwcsuite"));
     private static final String CLUSTER_NAME = System.getProperty("tests.clustername");


### PR DESCRIPTION
## Description

Upgrading to OpenSearch 2.18.0 including BWC tests as well.

---

- [x] All my commits include DCO.<br>_DCO stands for **Developer Certificate of Origin** and it is your declaration that your contribution is correctly attributed and licensed. Please read more about how to attach DCO to your commits [here](https://github.com/aiven/prometheus-exporter-plugin-for-opensearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) (spoiler alert: in most cases it is as simple as using `-s` option when doing `git commit`).<br>Please be aware that commits without DCO will cause failure of PR CI workflow and can not be merged._
