### PR TITLE
add dockerfile to build simply

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM gradle:8.12-jdk17
+
+RUN useradd -m -u 1001 -s /bin/bash appuser && \
+    apt-get update && \
+    apt-get install -y sudo && \ 
+    echo "appuser ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/appuser && \
+    chmod 440 /etc/sudoers.d/appuser 
+
+USER appuser
+
+RUN mkdir -p /home/appuser/app
+
+COPY . /home/appuser/app/
+
+RUN cd /home/appuser/app && sudo chown -R appuser:appuser . && ./gradlew --info build

--- a/README.md
+++ b/README.md
@@ -261,6 +261,24 @@ To build the plugin you need JDK 17:
 ```
 If you have doubts about the system requirements, please check the [CI.yml](.github/workflows/CI.yml) file for more information.
 
+## Build from Docker
+
+```
+docker build -t prometheus-exporter:v1 .
+```
+
+If you want intergrate the plugin to opensearch you can use the following Dockerfile:
+
+```
+FROM prometheus-exporter:v1 as plugin
+
+FROM opensearch:2.18.0
+
+COPY --from=plugin /home/appuser/app/build/distributions /root/
+
+RUN opensearch-plugin install -b file:///root/prometheus-exporter-2.18.0.0.zip
+```
+
 ## Testing
 
 Project contains:


### PR DESCRIPTION
## Description

Compile from the source is a little difficult.

I think we need dockerfile to make compiling more efficient.

---

- [x] All my commits include DCO.<br>_DCO stands for **Developer Certificate of Origin** and it is your declaration that your contribution is correctly attributed and licensed. Please read more about how to attach DCO to your commits [here](https://github.com/aiven/prometheus-exporter-plugin-for-opensearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) (spoiler alert: in most cases it is as simple as using `-s` option when doing `git commit`).<br>Please be aware that commits without DCO will cause failure of PR CI workflow and can not be merged._
