### PR TITLE
Upgrade to OpenSearch 3.3.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,7 @@ buildscript {
 
     repositories {
         mavenLocal()
+        maven { url "https://central.sonatype.com/repository/maven-snapshots/" }
         maven { url "https://aws.oss.sonatype.org/content/repositories/releases" }
         maven { url "https://aws.oss.sonatype.org/content/repositories/snapshots" }
         mavenCentral()
@@ -69,6 +70,7 @@ validateNebulaPom.enabled = false
 
 repositories {
     mavenLocal()
+    maven { url "https://central.sonatype.com/repository/maven-snapshots/" }
     maven { url "https://aws.oss.sonatype.org/content/repositories/releases" }
     maven { url "https://aws.oss.sonatype.org/content/repositories/snapshots" }
     mavenCentral()

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,15 +1,15 @@
 #group = org.opensearch.plugin.prometheus
 
 # An actual version of plugin
-version = 3.2.0.0
+version = 3.3.0.0
 
-opensearch_version = 3.2.0-SNAPSHOT
+opensearch_version = 3.3.0-SNAPSHOT
 
 # A version of OpenSearch cluster to run BWC tests against
-BWCversion = 3.1.0
+BWCversion = 3.2.0
 
 # A version of plugin to deploy to BWC clusters
-BWCPluginVersion = 3.1.0.0
+BWCPluginVersion = 3.2.0.0
 
 pluginName = prometheus-exporter
 pluginClassname = org.opensearch.plugin.prometheus.PrometheusExporterPlugin

--- a/src/main/java/org/compuscene/metrics/prometheus/PrometheusMetricsCollector.java
+++ b/src/main/java/org/compuscene/metrics/prometheus/PrometheusMetricsCollector.java
@@ -640,14 +640,14 @@ public class PrometheusMetricsCollector {
     private void updateIngestMetrics(Tuple<String, String> nodeInfo, IngestStats is) {
         if (is != null) {
             catalog.setNodeGauge(nodeInfo, "ingest_total_count", is.getTotalStats().getCount());
-            catalog.setNodeGauge(nodeInfo, "ingest_total_time_seconds", is.getTotalStats().getTotalTimeInMillis() / 1000.0);
+            catalog.setNodeGauge(nodeInfo, "ingest_total_time_seconds", is.getTotalStats().getTotalTime() / 1000.0);
             catalog.setNodeGauge(nodeInfo, "ingest_total_current", is.getTotalStats().getCurrent());
             catalog.setNodeGauge(nodeInfo, "ingest_total_failed_count", is.getTotalStats().getFailedCount());
 
             for (IngestStats.PipelineStat st : is.getPipelineStats()) {
                 String pipeline = st.getPipelineId();
                 catalog.setNodeGauge(nodeInfo, "ingest_pipeline_total_count", st.getStats().getCount(), pipeline);
-                catalog.setNodeGauge(nodeInfo, "ingest_pipeline_total_time_seconds", st.getStats().getTotalTimeInMillis() / 1000.0, pipeline);
+                catalog.setNodeGauge(nodeInfo, "ingest_pipeline_total_time_seconds", st.getStats().getTotalTime() / 1000.0, pipeline);
                 catalog.setNodeGauge(nodeInfo, "ingest_pipeline_total_current", st.getStats().getCurrent(), pipeline);
                 catalog.setNodeGauge(nodeInfo, "ingest_pipeline_total_failed_count", st.getStats().getFailedCount(), pipeline);
 
@@ -656,7 +656,7 @@ public class PrometheusMetricsCollector {
                     for (IngestStats.ProcessorStat ps : pss) {
                         String processor = ps.getName();
                         catalog.setNodeGauge(nodeInfo, "ingest_pipeline_processor_total_count", ps.getStats().getCount(), pipeline, processor);
-                        catalog.setNodeGauge(nodeInfo, "ingest_pipeline_processor_total_time_seconds", ps.getStats().getTotalTimeInMillis() / 1000.0, pipeline, processor);
+                        catalog.setNodeGauge(nodeInfo, "ingest_pipeline_processor_total_time_seconds", ps.getStats().getTotalTime() / 1000.0, pipeline, processor);
                         catalog.setNodeGauge(nodeInfo, "ingest_pipeline_processor_total_current", ps.getStats().getCurrent(), pipeline, processor);
                         catalog.setNodeGauge(nodeInfo, "ingest_pipeline_processor_total_failed_count", ps.getStats().getFailedCount(), pipeline, processor);
                     }

--- a/src/test/java/org/opensearch/plugin/bwc/PluginBackwardsCompatibilityIT.java
+++ b/src/test/java/org/opensearch/plugin/bwc/PluginBackwardsCompatibilityIT.java
@@ -34,8 +34,8 @@ import java.util.stream.Collectors;
  */
 public class PluginBackwardsCompatibilityIT extends OpenSearchRestTestCase {
 
-    public static final Version BWCVersion = Version.V_3_1_0;
-    public static final Version NewVersion = Version.V_3_2_0;
+    public static final Version BWCVersion = Version.V_3_2_0;
+    public static final Version NewVersion = Version.V_3_3_0;
 
     private static final ClusterType CLUSTER_TYPE = ClusterType.parse(System.getProperty("tests.rest.bwcsuite"));
     private static final String CLUSTER_NAME = System.getProperty("tests.clustername");


### PR DESCRIPTION
### Description
- Upgrade to OpenSearch 3.3.0
- Change OperationStats ```getTotalTimeInMillis()``` calls to ```getTotalTime()``` as that was changed in 3.3.0 (default is millis) 
	- class: https://github.com/opensearch-project/OpenSearch/blob/main/server/src/main/java/org/opensearch/common/metrics/OperationStats.java
	- PR with change: https://github.com/opensearch-project/OpenSearch/pull/19128/files#diff-ad6671b896d3e6cc245369defce9daabeb7f1301dc9e8cb4e714f468d9a39ba8

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/opensearch-prometheus-exporter/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).