### PR TITLE
Update Backport flow

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   backport:
+    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -15,7 +16,7 @@ jobs:
     steps:
       - name: GitHub App token
         id: github_app_token
-        uses: tibdex/github-app-token@v1.5.0
+        uses: tibdex/github-app-token@v2.1.0
         with:
           app_id: ${{ secrets.APP_ID }}
           private_key: ${{ secrets.APP_PRIVATE_KEY }}
@@ -25,4 +26,5 @@ jobs:
         uses: VachaShah/backport@v2.2.0
         with:
           github_token: ${{ steps.github_app_token.outputs.token }}
-          branch_name: backport/backport-${{ github.event.number }}
+          head_template: backport/backport-<%= number %>-to-<%= base %>
+          failure_labels: backport-failed


### PR DESCRIPTION
### Description

- Upgrading github-app-token from 1.5.0 to 2.1.0
- Making the backport job run conditional should unblock #352
- Taking head_template from the security plugin backport config

### Related Issues

Related issue: #352 

### Check List
- _[ ] New functionality includes testing._
- _[ ] New functionality has been documented._
- _[ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)._
- [x] Commits are signed per the DCO using `--signoff`.
- _[ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)._

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/opensearch-prometheus-exporter/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).