### PR TITLE
Add 1.3.20.0 release date in Compatibility Matrix

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -37,6 +37,7 @@ NOTE: OpenSearch plugins much match _exactly_ in major.minor.path version to the
 |      2.0.1 |     2.0.1.0 | July 12, 2022 |
 |      2.0.0 |     2.0.0.0 |  May 27, 2022 |
 |  2.0.0-rc1 | 2.0.0.0-rc1 |  May 19, 2022 |
+|     1.3.20 |    1.3.20.0 |  Oct 21, 2025 |
 |     1.3.19 |    1.3.19.0 |  Sep 25, 2024 |
 |     1.3.18 |    1.3.18.0 |  Sep 25, 2024 |
 |     1.3.17 |    1.3.17.0 |  Jun 26, 2024 |


### PR DESCRIPTION
### Description

Updating compatibility matrix to make it in sync with v1.3 branch.

### Related Issues

See: #327
See: #400 

### Check List
- [ ] _New functionality includes testing._
- [ ] _New functionality has been documented._
- [ ] _API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)._
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] _Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)._

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/opensearch-prometheus-exporter/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).