### PR TITLE
Adds concurrent segment search metrics

### DIFF
--- a/src/main/java/org/compuscene/metrics/prometheus/PrometheusMetricsCollector.java
+++ b/src/main/java/org/compuscene/metrics/prometheus/PrometheusMetricsCollector.java
@@ -198,6 +198,7 @@ public class PrometheusMetricsCollector {
         catalog.registerNodeGauge("indices_search_concurrent_query_count", "Count of search queries that use concurrent segment search");
         catalog.registerNodeGauge("indices_search_concurrent_query_current_number", "Current rate of search queries that use concurrent segment search");
         catalog.registerNodeGauge("indices_search_concurrent_query_time_seconds", "Time spent on search queries that use concurrent segment search");
+        catalog.registerNodeGauge("indices_search_concurrent_avg_slice_count", "Average slice count per concurrent segment search request");
 
         catalog.registerNodeGauge("indices_merges_current_number", "Current rate of merges");
         catalog.registerNodeGauge("indices_merges_current_docs_number", "Current rate of documents merged");
@@ -297,6 +298,7 @@ public class PrometheusMetricsCollector {
             catalog.setNodeGauge(nodeInfo,"indices_search_concurrent_query_current_number", idx.getSearch().getTotal().getConcurrentQueryCurrent());
             catalog.setNodeGauge(nodeInfo,"indices_search_concurrent_query_time_seconds",
                     idx.getSearch().getTotal().getConcurrentQueryTimeInMillis() / 1000.0);
+            catalog.setNodeGauge(nodeInfo,"indices_search_concurrent_avg_slice_count", idx.getSearch().getTotal().getConcurrentAvgSliceCount());
 
             catalog.setNodeGauge(nodeInfo,"indices_merges_current_number", idx.getMerge().getCurrent());
             catalog.setNodeGauge(nodeInfo,"indices_merges_current_docs_number", idx.getMerge().getCurrentNumDocs());

--- a/src/yamlRestTest/resources/rest-api-spec/test/30_25_index_concurrent_search.yml
+++ b/src/yamlRestTest/resources/rest-api-spec/test/30_25_index_concurrent_search.yml
@@ -41,3 +41,13 @@
         ,\} \s+ \d+\.\d+
         .*/
 
+  # Test indices_search_concurrent_avg_slice_count
+  - match:
+      $body: |
+        /.*
+        \# \s HELP \s opensearch_indices_search_concurrent_avg_slice_count \s Average \s slice \s count \s per \s concurrent \s segment \s search \s request \n
+        \# \s TYPE \s opensearch_indices_search_concurrent_avg_slice_count \s gauge \n
+        opensearch_indices_search_concurrent_avg_slice_count\{
+            cluster="yamlRestTest",node="[a-zA-Z0-9\-\.\_]+",nodeid="[a-zA-Z0-9\-\.\_]+"
+        ,\} \s+ \d+\.\d+
+        .*/


### PR DESCRIPTION
### Description
This PR adds support for three new metrics that track concurrent segment search performance in OpenSearch:

- opensearch_indices_search_concurrent_query_count: Total count of search queries that use concurrent segment search
- opensearch_indices_search_concurrent_query_current_number: Current number of active concurrent segment search queries
- opensearch_indices_search_concurrent_query_time_seconds: Total time spent on concurrent segment search queries

These attributes are already available on nodeInfo but are just are not emitted.

### Related Issues
https://github.com/opensearch-project/opensearch-prometheus-exporter/issues/408

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/opensearch-prometheus-exporter/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).