### PR TITLE
Fixes : #442 :: Add null check for ClusterIndexHealth in PrometheusMetricsCollector

### DIFF
--- a/src/main/java/org/compuscene/metrics/prometheus/PrometheusMetricsCollector.java
+++ b/src/main/java/org/compuscene/metrics/prometheus/PrometheusMetricsCollector.java
@@ -459,17 +459,19 @@ public class PrometheusMetricsCollector {
             for (Map.Entry<String, IndexStats> entry : isr.getIndices().entrySet()) {
                 String indexName = entry.getKey();
                 ClusterIndexHealth cih = chr.getIndices().get(indexName);
-                catalog.setClusterGauge("index_status", cih.getStatus().value(), indexName);
-                catalog.setClusterGauge("index_replicas_number", cih.getNumberOfReplicas(), indexName);
-                catalog.setClusterGauge("index_shards_number", cih.getActiveShards(), "active", indexName);
-                catalog.setClusterGauge("index_shards_number", cih.getNumberOfShards(), "shards", indexName);
-                catalog.setClusterGauge("index_shards_number", cih.getActivePrimaryShards(), "active_primary", indexName);
-                catalog.setClusterGauge("index_shards_number", cih.getInitializingShards(), "initializing", indexName);
-                catalog.setClusterGauge("index_shards_number", cih.getRelocatingShards(), "relocating", indexName);
-                catalog.setClusterGauge("index_shards_number", cih.getUnassignedShards(), "unassigned", indexName);
-                IndexStats indexStats = entry.getValue();
-                updatePerIndexContextMetrics(indexName, "total", indexStats.getTotal());
-                updatePerIndexContextMetrics(indexName, "primaries", indexStats.getPrimaries());
+                if (cih != null) {
+                    catalog.setClusterGauge("index_status", cih.getStatus().value(), indexName);
+                    catalog.setClusterGauge("index_replicas_number", cih.getNumberOfReplicas(), indexName);
+                    catalog.setClusterGauge("index_shards_number", cih.getActiveShards(), "active", indexName);
+                    catalog.setClusterGauge("index_shards_number", cih.getNumberOfShards(), "shards", indexName);
+                    catalog.setClusterGauge("index_shards_number", cih.getActivePrimaryShards(), "active_primary", indexName);
+                    catalog.setClusterGauge("index_shards_number", cih.getInitializingShards(), "initializing", indexName);
+                    catalog.setClusterGauge("index_shards_number", cih.getRelocatingShards(), "relocating", indexName);
+                    catalog.setClusterGauge("index_shards_number", cih.getUnassignedShards(), "unassigned", indexName);
+                    IndexStats indexStats = entry.getValue();
+                    updatePerIndexContextMetrics(indexName, "total", indexStats.getTotal());
+                    updatePerIndexContextMetrics(indexName, "primaries", indexStats.getPrimaries());
+                }
             }
         }
     }


### PR DESCRIPTION
### Description
Added null check for ClusterIndexHealth in PrometheusMetricsCollector

### Related Issues
Resolves #442 
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/opensearch-prometheus-exporter/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).