### PR TITLE
Major ClusterStatsData refactoring

### DIFF
--- a/src/main/java/org/compuscene/metrics/prometheus/PrometheusMetricsCollector.java
+++ b/src/main/java/org/compuscene/metrics/prometheus/PrometheusMetricsCollector.java
@@ -52,9 +52,9 @@ import io.prometheus.client.Summary;
  */
 public class PrometheusMetricsCollector {
 
-    private boolean isPrometheusClusterSettings;
-    private boolean isPrometheusIndices;
-    private PrometheusMetricsCatalog catalog;
+    private final boolean isPrometheusClusterSettings;
+    private final boolean isPrometheusIndices;
+    private final PrometheusMetricsCatalog catalog;
 
     /**
      * A constructor.

--- a/src/main/java/org/compuscene/metrics/prometheus/PrometheusSettings.java
+++ b/src/main/java/org/compuscene/metrics/prometheus/PrometheusSettings.java
@@ -25,7 +25,7 @@ import org.opensearch.common.settings.Settings;
 
 /**
  * Dynamically updatable Prometheus exporter settings.
- *
+ * <p>
  * These settings are part of the cluster state available via
  * <pre>{@code
  * curl <opensearch>/_cluster/settings?include_defaults=true&filter_path=defaults.prometheus
@@ -43,7 +43,7 @@ public class PrometheusSettings {
         /** See {@link IndicesOptions#strictExpandOpenAndForbidClosed()}  */
         STRICT_EXPAND_OPEN_FORBID_CLOSED,
         /**
-         * Note: There is a missing static method in the upstream.
+         * Note: There is a missing static method in the upstream (should be fixed in OpenSearch 3.6.0).
          * Tracks <a href="https://github.com/opensearch-project/OpenSearch/issues/20963">OpenSearch issue #20963</a>.
          */
         STRICT_EXPAND_OPEN_HIDDEN_FORBID_CLOSED,
@@ -104,10 +104,10 @@ public class PrometheusSettings {
                     Setting.Property.Dynamic, Setting.Property.NodeScope);
 
     /**
-     * This setting determines name expansion mechanism for matching indices.
+     * This setting determines an index name expansion mechanism for matching indices.
      * The default value is {@link INDEX_FILTER_OPTIONS#STRICT_EXPAND_OPEN_FORBID_CLOSED}.
      * Can be configured in <code>opensearch.yml</code> file or updated dynamically under key {@link #PROMETHEUS_SELECTED_OPTION_KEY}.
-     *
+     * <p>
      * See {@link IndicesOptions} for more information.
      */
     public static final Setting<INDEX_FILTER_OPTIONS> PROMETHEUS_SELECTED_OPTION =
@@ -204,6 +204,7 @@ public class PrometheusSettings {
                 indicesOptions = IndicesOptions.strictExpandOpenAndForbidClosed();
                 break;
             case STRICT_EXPAND_OPEN_HIDDEN_FORBID_CLOSED:
+                //indicesOptions = IndicesOptions.strictExpandOpenHiddenAndForbidClosed(); // from OpenSearch 3.6.0
                 indicesOptions = IndicesOptions.STRICT_EXPAND_OPEN_HIDDEN_FORBID_CLOSED;
                 break;
             case STRICT_EXPAND_OPEN_FORBID_CLOSED_IGNORE_THROTTLED:

--- a/src/main/java/org/opensearch/action/ClusterStatsData.java
+++ b/src/main/java/org/opensearch/action/ClusterStatsData.java
@@ -35,43 +35,36 @@ import java.io.IOException;
 
 /**
  * Selected settings from OpenSearch cluster settings.
- *
- * Disk-based shard allocation [1] settings play important role in how OpenSearch decides where to allocate
+ * <p>
+ * Disk-based shard allocation [1] settings play an important role in how OpenSearch decides where to allocate
  * new shards or if existing shards are relocated to different nodes. The tricky part about these settings is
- * that they can be expressed either in percent or bytes value (they cannot be mixed) and they can be updated on the fly.
- *
- * TODO[lukas-vlcek]: Update docs URL
- * [1] https://www.elastic.co/guide/en/elasticsearch/reference/master/disk-allocator.html#disk-allocator
- *
- * In order to make it easy for Prometheus to consume the data we expose these settings in both formats (pct and bytes)
- * and we do our best in determining if they are currently set as pct or bytes filling appropriate variables with data
- * or null value.
+ * that they can be expressed either in percent or bytes value (they cannot be mixed), and they can be updated
+ * on the fly [2].
+ * <ul>
+ *   <li> [1] <a href="https://docs.opensearch.org/latest/install-and-configure/configuring-opensearch/cluster-settings/">Cluster Settings ("cluster.routing.allocation.disk.watermark.*")</a></li>
+ *   <li> [2] <a href="https://docs.opensearch.org/latest/api-reference/popular-api/#change-disk-watermarks-or-other-cluster-settings">Change disk watermark</a></li>
+ * </ul>
+ * <p>
+ * To make it easy for Prometheus to consume the data, we expose these settings in both formats (pct and bytes)
+ * and we do our best in determining if they are currently set as pct or bytes filling appropriate variables
+ * with data or null value.
  */
-// TODO(lukas-vlcek): should this extend TransportMessage instead?
 public class ClusterStatsData extends ActionResponse {
 
-    private Boolean thresholdEnabled = null;
+    @Nullable private final Boolean thresholdEnabled;
 
-    @Nullable private Long diskLowInBytes;
-    @Nullable private Long diskHighInBytes;
-    @Nullable private Long floodStageInBytes;
+    @Nullable private final Long diskLowInBytes;
+    @Nullable private final Long diskHighInBytes;
+    @Nullable private final Long floodStageInBytes;
 
-    @Nullable private Double diskLowInPct;
-    @Nullable private Double diskHighInPct;
-    @Nullable private Double floodStageInPct;
-
-    private Long[] diskLowInBytesRef = new Long[]{diskLowInBytes};
-    private Long[] diskHighInBytesRef = new Long[]{diskHighInBytes};
-    private Long[] floodStageInBytesRef = new Long[]{floodStageInBytes};
-
-    private Double[] diskLowInPctRef = new Double[]{diskLowInPct};
-    private Double[] diskHighInPctRef = new Double[]{diskHighInPct};
-    private Double[] floodStageInPctRef = new Double[]{floodStageInPct};
+    @Nullable private final Double diskLowInPct;
+    @Nullable private final Double diskHighInPct;
+    @Nullable private final Double floodStageInPct;
 
     /**
      * A constructor.
-     * @param in A streamInput to materialize the instance from
-     * @throws IOException if reading from streamInput is not successful
+     * @param in A {@link StreamInput} to materialize the instance from
+     * @throws IOException if reading from {@link StreamInput} is not successful
      */
     public ClusterStatsData(StreamInput in) throws IOException {
         super(in);
@@ -89,61 +82,85 @@ public class ClusterStatsData extends ActionResponse {
     @SuppressWarnings({"checkstyle:LineLength"})
     ClusterStatsData(ClusterStateResponse clusterStateResponse, Settings settings, ClusterSettings clusterSettings) {
 
-        Metadata m = clusterStateResponse.getState().getMetadata();
-        // There are several layers of cluster settings in Elasticsearch each having different priority.
-        // We need to traverse them from the top priority down to find relevant value of each setting.
-        // See https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-update-settings.html#_order_of_precedence
-        // TODO[lukas-vlcek]: update to OpenSearch referenced
-        for (Settings s : new Settings[]{
-                // See: RestClusterGetSettingsAction#response
-                // or: https://github.com/elastic/elasticsearch/pull/33247/files
-                // We do not filter the settings, but we use the clusterSettings.diff()
-                // In the end we expose just a few selected settings ATM.
-                m.transientSettings(),
-                m.persistentSettings(),
-                clusterSettings.diff(m.settings(), settings)
-        }) {
-            thresholdEnabled = thresholdEnabled == null ?
-                    s.getAsBoolean(CLUSTER_ROUTING_ALLOCATION_DISK_THRESHOLD_ENABLED_SETTING.getKey(), null) : thresholdEnabled;
+        Metadata metadata = clusterStateResponse.getState().getMetadata();
 
-            parseValue(s, CLUSTER_ROUTING_ALLOCATION_LOW_DISK_WATERMARK_SETTING.getKey(), diskLowInBytesRef, diskLowInPctRef);
-            parseValue(s, CLUSTER_ROUTING_ALLOCATION_HIGH_DISK_WATERMARK_SETTING.getKey(), diskHighInBytesRef, diskHighInPctRef);
-            parseValue(s, CLUSTER_ROUTING_ALLOCATION_DISK_FLOOD_STAGE_WATERMARK_SETTING.getKey(), floodStageInBytesRef, floodStageInPctRef);
+        Boolean resolvedThresholdEnabled = null;
+        Long resolvedDiskLowInBytes = null;
+        Long resolvedDiskHighInBytes = null;
+        Long resolvedFloodStageInBytes = null;
+        Double resolvedDiskLowInPct = null;
+        Double resolvedDiskHighInPct = null;
+        Double resolvedFloodStageInPct = null;
+
+        // There are several layers of cluster settings in OpenSearch each having different priority.
+        // We need to traverse them from the top priority down to find relevant value of each setting.
+        // See https://docs.opensearch.org/latest/install-and-configure/configuring-opensearch/index/#updating-cluster-settings-using-the-api
+        for (Settings currentSettings : new Settings[]{
+                metadata.transientSettings(),
+                metadata.persistentSettings(),
+                clusterSettings.diff(metadata.settings(), settings)
+        }) {
+            if (resolvedThresholdEnabled == null) {
+                resolvedThresholdEnabled = currentSettings.getAsBoolean(
+                        CLUSTER_ROUTING_ALLOCATION_DISK_THRESHOLD_ENABLED_SETTING.getKey(), null);
+            }
+
+            LongValue parsedLow = parseWatermarkValue(
+                    currentSettings,
+                    CLUSTER_ROUTING_ALLOCATION_LOW_DISK_WATERMARK_SETTING.getKey());
+            resolvedDiskLowInBytes = firstNonNull(resolvedDiskLowInBytes, parsedLow.bytes());
+            resolvedDiskLowInPct = firstNonNull(resolvedDiskLowInPct, parsedLow.pct());
+
+            LongValue parsedHigh = parseWatermarkValue(
+                    currentSettings,
+                    CLUSTER_ROUTING_ALLOCATION_HIGH_DISK_WATERMARK_SETTING.getKey());
+            resolvedDiskHighInBytes = firstNonNull(resolvedDiskHighInBytes, parsedHigh.bytes());
+            resolvedDiskHighInPct = firstNonNull(resolvedDiskHighInPct, parsedHigh.pct());
+
+            LongValue parsedFlood = parseWatermarkValue(
+                    currentSettings,
+                    CLUSTER_ROUTING_ALLOCATION_DISK_FLOOD_STAGE_WATERMARK_SETTING.getKey());
+            resolvedFloodStageInBytes = firstNonNull(resolvedFloodStageInBytes, parsedFlood.bytes());
+            resolvedFloodStageInPct = firstNonNull(resolvedFloodStageInPct, parsedFlood.pct());
         }
 
-        diskLowInBytes = diskLowInBytesRef[0];
-        diskHighInBytes = diskHighInBytesRef[0];
-        floodStageInBytes = floodStageInBytesRef[0];
-
-        diskLowInPct = diskLowInPctRef[0];
-        diskHighInPct = diskHighInPctRef[0];
-        floodStageInPct = floodStageInPctRef[0];
+        thresholdEnabled = resolvedThresholdEnabled;
+        diskLowInBytes = resolvedDiskLowInBytes;
+        diskHighInBytes = resolvedDiskHighInBytes;
+        floodStageInBytes = resolvedFloodStageInBytes;
+        diskLowInPct = resolvedDiskLowInPct;
+        diskHighInPct = resolvedDiskHighInPct;
+        floodStageInPct = resolvedFloodStageInPct;
     }
 
-    /**
-     * Try to extract and parse value from settings for given key.
-     * First it tries to parse it as a RatioValue (pct) then as byte size value.
-     * It assigns parsed value to corresponding argument references (passed via array hack).
-     * If parsing fails the method fires exception, however, this should not happen - we rely on Elasticsearch
-     * to already have parsed and validated these values before. Unless we screwed something up...
-     */
-    private void parseValue(Settings s, String key, Long[] bytesPointer, Double[] pctPointer) {
-        String value = s.get(key);
-        if (value != null && pctPointer[0] == null) {
+    private record LongValue(@Nullable Long bytes, @Nullable Double pct) {
+
+        private static LongValue empty() {
+            return new LongValue(null, null);
+        }
+    }
+
+    private LongValue parseWatermarkValue(Settings settings, String key) {
+        String value = settings.get(key);
+        if (value == null) {
+            return LongValue.empty();
+        }
+
+        try {
+            Double pct = RatioValue.parseRatioValue(value).getAsPercent();
+            return new LongValue(null, pct);
+        } catch (SettingsException | OpenSearchParseException | NullPointerException ignored) {
             try {
-                pctPointer[0] = RatioValue.parseRatioValue(s.get(key, null)).getAsPercent();
-            } catch (SettingsException | OpenSearchParseException | NullPointerException e1) {
-                if (bytesPointer[0] == null) {
-                    try {
-                        bytesPointer[0] = s.getAsBytesSize(key, null).getBytes();
-                    } catch (SettingsException | OpenSearchParseException | NullPointerException e2) {
-                        // TODO(lvlcek): log.debug("This went wrong, but 'Keep Calm and Carry On'")
-                        // We should avoid using logs in this class (due to perf impact), instead we should
-                        // consider moving this logic to some static helper class/method going forward.
-                    }
-                }
+                Long bytes = settings.getAsBytesSize(key, null).getBytes();
+                return new LongValue(bytes, null);
+            } catch (SettingsException | OpenSearchParseException | NullPointerException ignoredAgain) {
+                return LongValue.empty();
             }
         }
+    }
+
+    private static <T> T firstNonNull(@Nullable T current, @Nullable T candidate) {
+        return current != null ? current : candidate;
     }
 
     @Override
@@ -163,6 +180,7 @@ public class ClusterStatsData extends ActionResponse {
      * Get value of setting controlled by {@link org.opensearch.cluster.routing.allocation.DiskThresholdSettings#CLUSTER_ROUTING_ALLOCATION_DISK_THRESHOLD_ENABLED_SETTING}.
      * @return A Boolean value of the setting.
      */
+    @Nullable
     public Boolean getThresholdEnabled() {
         return thresholdEnabled;
     }

--- a/src/main/java/org/opensearch/action/NodePrometheusMetricsResponse.java
+++ b/src/main/java/org/opensearch/action/NodePrometheusMetricsResponse.java
@@ -34,8 +34,8 @@ import java.io.IOException;
 
 /**
  * Action response class for Prometheus Exporter plugin.
- * This class a container of other responses that are needed to construct list of all required metrics. It knows how to
- * prepare all data for wire transport by writing it into outputStream.
+ * This class is a container of other responses that are needed to construct a list of all required metrics. It knows how to
+ * prepare all data for wire transport by writing it into the {@link StreamOutput}.
  */
 public class NodePrometheusMetricsResponse extends ActionResponse {
     private final ClusterHealthResponse clusterHealth;
@@ -45,9 +45,9 @@ public class NodePrometheusMetricsResponse extends ActionResponse {
     private ClusterStatsData clusterStatsData = null;
 
     /**
-     * A constructor that materialize the instance from inputStream.
+     * A constructor that materializes the instance from {@link StreamInput}.
      * @param in inputStream
-     * @throws IOException if there is an exception reading from inputStream
+     * @throws IOException if there is an exception reading from {@link StreamInput}
      */
     public NodePrometheusMetricsResponse(StreamInput in) throws IOException {
         super(in);

--- a/src/main/java/org/opensearch/action/TransportNodePrometheusMetricsAction.java
+++ b/src/main/java/org/opensearch/action/TransportNodePrometheusMetricsAction.java
@@ -48,7 +48,7 @@ import org.opensearch.transport.TransportService;
  * Transport action class for Prometheus Exporter plugin.
  *
  * It performs several requests within the cluster to gather "cluster health", "local nodes info", "nodes stats", "indices stats"
- * and "cluster state" (i.e. cluster settings) info. Some of those requests are optional depending on plugin
+ * and "cluster state" (i.e., cluster settings) info. Some of those requests are optional depending on plugin
  * settings.
  */
 public class TransportNodePrometheusMetricsAction extends HandledTransportAction<NodePrometheusMetricsRequest,
@@ -109,24 +109,21 @@ public class TransportNodePrometheusMetricsAction extends HandledTransportAction
         // All the requests are executed in sequential non-blocking order.
         // It is implemented by wrapping each individual request with ActionListener
         // and chaining all of them into a sequence. The last member of the chain call method that gathers
-        // all the responses from previous requests and pass them to outer listener (i.e. calling client).
+        // all the responses from previous requests and passes them to outer listener (i.e., calling client).
         // Optional requests are skipped.
         //
-        // In the future we might consider executing all the requests in parallel if needed (CountDownLatch?),
-        // however, some of the requests can impact cluster performance (especially if the cluster is already overloaded)
-        // and in this situation it is better to run all requests in predictable order so that collected metrics
+        // In the future we might consider executing all requests in parallel if needed (CountDownLatch?),
+        // however, some requests can impact cluster performance (especially if the cluster is already overloaded),
+        // and in this situation it is better to execute all requests in predictable order so that collected metrics
         // stay consistent.
         private AsyncAction(ActionListener<NodePrometheusMetricsResponse> listener) {
             this.listener = listener;
 
-            // Note: when using ClusterHealthRequest in Java, it pulls data at the shards level, according to ES source
-            // code comment this is "so it is backward compatible with the transport client behaviour".
-            // hence we are explicit about ClusterHealthRequest level and do not rely on defaults.
-            // https://www.elastic.co/guide/en/elasticsearch/reference/6.4/cluster-health.html#request-params
+            // Do not rely on ClusterHealthRequest defaults and set an explicit level of information.
             this.healthRequest = Requests.clusterHealthRequest().local(true);
             this.healthRequest.level(ClusterHealthRequest.Level.SHARDS);
 
-            // We want to get only the most minimal static info from local node (cluster name, node name and nodeID).
+            // We want to get only the most minimal static info from the local node (cluster name, node name and nodeID).
             this.localNodesInfoRequest = Requests.nodesInfoRequest("_local").clear();
 
             this.nodesStatsRequest = Requests.nodesStatsRequest(prometheusNodesFilter).clear().all();
@@ -142,8 +139,7 @@ public class TransportNodePrometheusMetricsAction extends HandledTransportAction
                 this.indicesStatsRequest = null;
             }
 
-            // Cluster settings are get via ClusterStateRequest (see elasticsearch RestClusterGetSettingsAction for details)
-            // We prefer to send it to master node (hence local=false; it should be set by default but we want to be sure).
+            // Cluster settings are pulled from the cluster manager node (hence local=false).
             this.clusterStateRequest = isPrometheusClusterSettings ? Requests.clusterStateRequest()
                     .clear().metadata(true).local(false) : null;
         }

--- a/src/yamlRestTest/resources/rest-api-spec/test/40_10_cluster_settings_disk_threshold.yml
+++ b/src/yamlRestTest/resources/rest-api-spec/test/40_10_cluster_settings_disk_threshold.yml
@@ -2,8 +2,8 @@
 "Cluster settings statistics: disk threshold":
 
   # -----------------------------------
-  # By default cluster.routing.allocation.disk.threshold_enabled is set to true.
-  # https://www.elastic.co/guide/en/elasticsearch/reference/master/disk-allocator.html
+  # By default "cluster.routing.allocation.disk.threshold_enabled" setting is set to 'true'.
+  # See: org.opensearch.cluster.routing.allocation.DiskThresholdSettings
   # OOTB there are no transient or persistent settings in the cluster:
   - do:
       cluster.get_settings:

--- a/src/yamlRestTest/resources/rest-api-spec/test/40_20_cluster_settings_disk_watermark_bytes.yml
+++ b/src/yamlRestTest/resources/rest-api-spec/test/40_20_cluster_settings_disk_watermark_bytes.yml
@@ -2,12 +2,10 @@
 "Cluster settings statistics: watermark":
 
   # -----------------------------------
-  # By default cluster.routing.allocation.disk.watermark.* are set according to:
-  # https://www.elastic.co/guide/en/elasticsearch/reference/master/disk-allocator.html
-  # ---
-  # However, the REST test framework sets these settings in ClusterFormationTasks.groovy to '1b'.
-  # Or see buildSrc/src/main/java/org/elasticsearch/gradle/testclusters/ElasticsearchNode.java
-  # Things seems to be still moving in Elasticsearch...
+  # By default "cluster.routing.allocation.disk.watermark.*" settings are set to '1b'.
+  # See: org.opensearch.gradle.testclusters.OpenSearchNode.java
+  # See: org.opensearch.gradle.test.ClusterFormationTasks.groovy (also to '1b').
+
   - do:
       cluster.get_settings:
         include_defaults: true
@@ -167,10 +165,97 @@
         (\n \# \s (HELP|TYPE).* | \s*)
         /
 
-  # Clean up the cluster state. See https://github.com/vvanholl/elasticsearch-prometheus-exporter/issues/154
+  # -----------------------------------
+  # Now define transient watermark values:
   - do:
       cluster.put_settings:
         body:
+          transient:
+            cluster.routing.allocation.disk.watermark.low: "50.0%"
+            cluster.routing.allocation.disk.watermark.high: "50.0%"
+            cluster.routing.allocation.disk.watermark.flood_stage: "50.0%"
+        flat_settings: true
+
+  - do:
+      cluster.get_settings:
+        include_defaults: true
+
+  - match: {transient.cluster.routing.allocation.disk.watermark.low: "50.0%"}
+  - match: {transient.cluster.routing.allocation.disk.watermark.high: "50.0%"}
+  - match: {transient.cluster.routing.allocation.disk.watermark.flood_stage: "50.0%"}
+
+  - match: {persistent.cluster.routing.allocation.disk.watermark.low: "99.9%"}
+  - match: {persistent.cluster.routing.allocation.disk.watermark.high: "99.9%"}
+  - match: {persistent.cluster.routing.allocation.disk.watermark.flood_stage: "99.9%"}
+
+  # Verify in Prometheus metrics:
+  - do:
+      prometheus.metrics: {}
+
+  - match:
+      $body: |
+        /.*
+        \# \s HELP \s opensearch_cluster_routing_allocation_disk_watermark_low_pct (\s|\w|\d)+ \n
+        \# \s TYPE \s opensearch_cluster_routing_allocation_disk_watermark_low_pct \s gauge \n
+        opensearch_cluster_routing_allocation_disk_watermark_low_pct\{
+            cluster="yamlRestTest"
+        \,} \s 50\.0 \n?
+        .*/
+
+  - match:
+      $body: |
+        /.*
+        \# \s HELP \s opensearch_cluster_routing_allocation_disk_watermark_high_pct (\s|\w|\d)+ \n
+        \# \s TYPE \s opensearch_cluster_routing_allocation_disk_watermark_high_pct \s gauge \n
+        opensearch_cluster_routing_allocation_disk_watermark_high_pct\{
+            cluster="yamlRestTest"
+        \,} \s 50\.0 \n?
+        .*/
+
+  - match:
+      $body: |
+        /.*
+        \# \s HELP \s opensearch_cluster_routing_allocation_disk_watermark_flood_stage_pct (\s|\w|\d)+ \n
+        \# \s TYPE \s opensearch_cluster_routing_allocation_disk_watermark_flood_stage_pct \s gauge \n
+        opensearch_cluster_routing_allocation_disk_watermark_flood_stage_pct\{
+            cluster="yamlRestTest"
+        \,} \s 50\.0 \n?
+        .*/
+
+  # At the same time all bytes alternatives do not report any metric values but they are still present.
+  # This is recommended, see https://prometheus.io/docs/practices/instrumentation/#avoid-missing-metrics
+  - match:
+      $body: |
+        /.*
+        \# \s HELP \s opensearch_cluster_routing_allocation_disk_watermark_low_bytes (\s|\w|\d)+ \n
+        \# \s TYPE \s opensearch_cluster_routing_allocation_disk_watermark_low_bytes \s gauge
+        (\n \# \s (HELP|TYPE).* | \s*)
+        /
+
+  - match:
+      $body: |
+        /.*
+        \# \s HELP \s opensearch_cluster_routing_allocation_disk_watermark_high_bytes (\s|\w|\d)+ \n
+        \# \s TYPE \s opensearch_cluster_routing_allocation_disk_watermark_high_bytes \s gauge
+        (\n \# \s (HELP|TYPE).* | \s*)
+        /
+
+  - match:
+      $body: |
+        /.*
+        \# \s HELP \s opensearch_cluster_routing_allocation_disk_watermark_flood_stage_bytes (\s|\w|\d)+ \n
+        \# \s TYPE \s opensearch_cluster_routing_allocation_disk_watermark_flood_stage_bytes \s gauge
+        (\n \# \s (HELP|TYPE).* | \s*)
+        /
+
+  # Clean up the cluster state.
+  - do:
+      cluster.put_settings:
+        body:
+          transient:
+            cluster.routing.allocation.disk.watermark.low: null
+            cluster.routing.allocation.disk.watermark.high: null
+            cluster.routing.allocation.disk.watermark.flood_stage: null
           persistent:
             cluster.routing.allocation.disk.watermark.low: null
             cluster.routing.allocation.disk.watermark.high: null

--- a/src/yamlRestTest/resources/rest-api-spec/test/40_30_cluster_settings_disk_watermark_mixing_fails.yml
+++ b/src/yamlRestTest/resources/rest-api-spec/test/40_30_cluster_settings_disk_watermark_mixing_fails.yml
@@ -1,0 +1,60 @@
+---
+"Cluster settings: watermark type mixing fails":
+
+  # -----------------------------------
+  # Cluster does not allow mixing different types of disk watermarks.
+  #
+  # By default "cluster.routing.allocation.disk.watermark.*" settings are set to '1b'.
+  # See: org.opensearch.gradle.testclusters.OpenSearchNode.java
+  # See: org.opensearch.gradle.test.ClusterFormationTasks.groovy (also to '1b').
+
+  - do:
+      cluster.get_settings:
+        include_defaults: true
+
+  - match: {persistent: {}}
+  - match: {transient: {}}
+  - match: {defaults.cluster.routing.allocation.disk.watermark.low: "1b"}
+  - match: {defaults.cluster.routing.allocation.disk.watermark.high: "1b"}
+  - match: {defaults.cluster.routing.allocation.disk.watermark.flood_stage: "1b"}
+
+  # -----------------------------------
+  # Setup custom persistent disk watermarks:
+  - do:
+      catch: /failed to parse setting \[cluster\.routing\.allocation\.disk\.watermark\.high\] with value \[99\.9\%\] as a size in bytes/
+      cluster.put_settings:
+        body:
+          persistent:
+            cluster.routing.allocation.disk.watermark.low: "5b"
+            cluster.routing.allocation.disk.watermark.high: "99.9%"
+        flat_settings: true
+
+  - do:
+      cluster.get_settings:
+        include_defaults: true
+
+  - match: {transient: {}}
+  # If mixing were possible, we would expect the following settings to be set:
+  #- match: {persistent.cluster.routing.allocation.disk.watermark.low: "5b"}
+  #- match: {persistent.cluster.routing.allocation.disk.watermark.high: "99.9%"}
+  #- match: {persistent.cluster.routing.allocation.disk.watermark.flood_stage: null}
+  #
+  # But because changing settings failed, we expect the default values:
+  - match: {persistent: {}}
+  - match: {defaults.cluster.routing.allocation.disk.watermark.low: "1b"}
+  - match: {defaults.cluster.routing.allocation.disk.watermark.high: "1b"}
+  - match: {defaults.cluster.routing.allocation.disk.watermark.flood_stage: "1b"}
+
+  # Clean up the cluster state.
+  - do:
+      cluster.put_settings:
+        body:
+          transient:
+            cluster.routing.allocation.disk.watermark.low: null
+            cluster.routing.allocation.disk.watermark.high: null
+            cluster.routing.allocation.disk.watermark.flood_stage: null
+          persistent:
+            cluster.routing.allocation.disk.watermark.low: null
+            cluster.routing.allocation.disk.watermark.high: null
+            cluster.routing.allocation.disk.watermark.flood_stage: null
+        flat_settings: true


### PR DESCRIPTION
### Description

A major refactoring of ClusterStatsData class includes the following:

- replaced "pointer" fields with a proper Java "LongValue" record
- making "data fields" final
- moved local variables into helper method because they are not part of object state
- split parsing logic into several smaller helper methods
- replaced silent parsing failure with explicit behavior (ie. empty LongValue)
- improved naming of internal variables
- extending REST test

Part of the refactoring is revisiting of javadoc and internal comments that contained references to documentation of project that the OpenSearch was forked from back in time.

Removed some references to the original @vvanholl's GitHub repository because he unfortunately dropped it some time ago.

### Related Issues

No particular issue is resolved by this PR. This is part of effort to revisit whole code-base and provide refreshed implementation where necessary. The focus is to improve code maintainability and remove bad coding patterns.

### Check List
- _[ ] New functionality includes testing._
- _[ ] New functionality has been documented._
- _[ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)._
- [x] Commits are signed per the DCO using `--signoff`.
- _[ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)._

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/opensearch-prometheus-exporter/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).