### PR TITLE
Fix missing javadoc warnings (#482)

### DIFF
--- a/src/main/java/org/compuscene/metrics/prometheus/PrometheusMetricsCatalog.java
+++ b/src/main/java/org/compuscene/metrics/prometheus/PrometheusMetricsCatalog.java
@@ -46,6 +46,7 @@ public class PrometheusMetricsCatalog {
     private CollectorRegistry registry;
 
     /**
+     * Creates a new PrometheusMetricsCatalog for the given cluster and metric prefix.
      *
      * @param clusterName   Name of the OpenSearch cluster
      * @param metricPrefix  A value that is automatically used as a prefix for all registered and set metrics

--- a/src/main/java/org/compuscene/metrics/prometheus/PrometheusMetricsCollector.java
+++ b/src/main/java/org/compuscene/metrics/prometheus/PrometheusMetricsCollector.java
@@ -980,6 +980,8 @@ public class PrometheusMetricsCollector {
     }
 
     /**
+     * Returns all collected metrics as a UTF-8 plain-text string in Prometheus exposition format.
+     *
      * @see PrometheusMetricsCatalog#toTextFormat()
      * @return A text representation of the catalog
      * @throws IOException If creating the text representation goes wrong

--- a/src/main/java/org/opensearch/action/admin/indices/stats/PackageAccessHelper.java
+++ b/src/main/java/org/opensearch/action/admin/indices/stats/PackageAccessHelper.java
@@ -26,6 +26,12 @@ import java.io.IOException;
 public class PackageAccessHelper {
 
     /**
+     * Default constructor for PackageAccessHelper.
+     */
+    public PackageAccessHelper() {
+    }
+
+    /**
      * Shortcut to IndicesStatsResponse constructor which has package access restriction.
      * @param in StreamInput
      * @return IndicesStatsResponse


### PR DESCRIPTION
### Description
Fix missing Javadoc warnings by adding explicit constructor with Javadoc comment to PackageAccessHelper, and adding main descriptions to the Javadoc blocks in PrometheusMetricsCatalog and PrometheusMetricsCollector.
### Related Issues
Resolves #482
Related to #480

### Check List
- _[ ] New functionality includes testing._
- [x] New functionality has been documented.
- _[ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)._
- [ ] Commits are signed per the DCO using `--signoff`.
- _[ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)._

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/opensearch-prometheus-exporter/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).