### PR TITLE
Enable plugin publication into local maven repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ The [Prometheus® exporter](https://prometheus.io/docs/instrumenting/writing_exp
 - [Introduction](#introduction)
 - [Compatibility Matrix](#compatibility-matrix)
 - [Install or Remove Plugin](#install-or-remove-plugin)
+- [Deploy Plugin into Local Maven Repository](#deploy-plugin-into-local-maven-repository)
 - [Plugin Configuration](#plugin-configuration)
   - [Static settings](#static-settings) 
   - [Dynamic settings](#dynamic-settings) 
@@ -62,6 +63,15 @@ To **remove** the plugin.
 `./bin/opensearch-plugin remove prometheus-exporter`
 
 For more info about plugin CLI, visit: <https://docs.opensearch.org/latest/install-and-configure/plugins/>
+
+## Deploy Plugin into Local Maven Repository
+
+Plugin can be deployed into local Maven repository using:
+
+```shell
+./gradlew clean build publishToMavenLocal --info
+```
+You can customize maven group coordinates by setting `group` property in `gradle.properties` file.
 
 ## Plugin Configuration
 

--- a/build.gradle
+++ b/build.gradle
@@ -30,10 +30,15 @@ buildscript {
     }
 }
 
+configurations {
+    zipArchive
+}
+
 apply plugin: 'java'
 apply plugin: 'idea'
 apply plugin: 'opensearch.opensearchplugin'
 apply plugin: 'opensearch.yaml-rest-test'
+apply plugin: 'opensearch.pluginzip'
 apply plugin: 'opensearch.java-agent'
 apply plugin: 'checkstyle'
 
@@ -48,6 +53,37 @@ checkstyle {
     showViolations true
     configDirectory.set(rootProject.file("config/checkstyle/"))
 }
+
+publishing {
+    publications {
+        pluginZip(MavenPublication) { publication ->
+            pom {
+                name = pluginName
+                description = pluginDescription
+                licenses {
+                    license {
+                        name = "The Apache License, Version 2.0"
+                        url = "http://www.apache.org/licenses/LICENSE-2.0.txt"
+                    }
+                }
+                developers {
+                    developer {
+                        name = "OpenSearch"
+                        url = "https://github.com/opensearch-project/opensearch-prometheus-exporter"
+                    }
+                }
+            }
+        }
+    }
+}
+
+// Add task dependencies to ensure proper execution order (ie. run PluginZip publication after Nebula publication).
+// However, because 'publishNebulaPublicationToMavenLocal' is disabled (see below) we do not need to specify explicit
+// order of Nebula and PluginZip publications. If for whatever reason we need to enable Nebula publishing as well, we
+// need to uncomment the following lines as well.
+//tasks.named("publishNebulaPublicationToMavenLocal") {
+//    dependsOn(tasks.named("generatePomFileForPluginZipPublication"))
+//}
 
 opensearchplugin {
     name pluginName
@@ -66,6 +102,10 @@ loggerUsageCheck.enabled = false
 
 // No need to validate pom, as we do not upload to maven/sonatype
 validateNebulaPom.enabled = false
+
+// Disable Nebula publication to avoid conflict with pluginZip publication.
+// This means we will get only pom and zip files in maven repository.
+tasks.named("publishNebulaPublicationToMavenLocal").configure { enabled = false }
 
 repositories {
     mavenLocal()

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,5 @@
-#group = org.opensearch.plugin.prometheus
+# Determines the maven coordinates for the plugin when published to maven
+group = org.opensearch.plugin.prometheus
 
 # An actual version of plugin
 version = 3.6.0.0


### PR DESCRIPTION
### Description

We can now deploy plugin into local maven repository using the following command:

```
./gradlew clean build publishToMavenLocal --info
```

The maven repo coordinates are specified `group` property in `gradle.properties` file.

We explicitly disable nebula publishing task in order to avoid overriding the pom file. If the nebula task needs to be enabled then a dependency of pluginZip publishing task on nebula publishing task needs to be configured (just uncomment prepared dependsOn() part). However, be aware that the build will print the following statement:

```
The publications 'nebula' in root project 'prometheus-exporter' and 'pluginZip' in root project 'prometheus-exporter' will overwrite each other!
Publishing to maven local repository
```

### Related Issues

Closes: #331

### Check List
- _[ ] New functionality includes testing._
- [x] New functionality has been documented.
- _[ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)._
- [x] Commits are signed per the DCO using `--signoff`.
- _[ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)._

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/opensearch-prometheus-exporter/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).