### PR TITLE
Bump to OpenSearch 3.7.0

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -4,6 +4,7 @@ NOTE: OpenSearch plugins must match _exactly_ in major.minor.patch version to th
 
 | OpenSearch |      Plugin |  Release date |
 |-----------:|------------:|--------------:|
+|      3.7.0 |     3.7.0.0 |  Jun 10, 2026 |
 |      3.6.0 |     3.6.0.0 |  Apr 16, 2026 |
 |      3.5.0 |     3.5.0.0 |  Feb 11, 2026 |
 |      3.4.0 |     3.4.0.0 |  Dec 17, 2025 |

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ You need to install the plugin on every OpenSearch node that will be scraped by 
 
 To **install** the plugin:
 
-`./bin/opensearch-plugin install https://github.com/opensearch-project/opensearch-prometheus-exporter/releases/download/3.6.0.0/prometheus-exporter-3.6.0.0.zip`
+`./bin/opensearch-plugin install https://github.com/opensearch-project/opensearch-prometheus-exporter/releases/download/3.7.0.0/prometheus-exporter-3.7.0.0.zip`
 
 To **remove** the plugin.
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,15 +2,15 @@
 group = org.opensearch.plugin.prometheus
 
 # An actual version of plugin
-version = 3.6.0.0
+version = 3.7.0.0
 
-opensearch_version = 3.6.0-SNAPSHOT
+opensearch_version = 3.7.0-SNAPSHOT
 
 # A version of OpenSearch cluster to run BWC tests against
-BWCversion = 3.5.0
+BWCversion = 3.6.0
 
 # A version of plugin to deploy to BWC clusters
-BWCPluginVersion = 3.5.0.0
+BWCPluginVersion = 3.6.0.0
 
 pluginName = prometheus-exporter
 pluginClassname = org.opensearch.plugin.prometheus.PrometheusExporterPlugin

--- a/src/main/java/org/compuscene/metrics/prometheus/PrometheusSettings.java
+++ b/src/main/java/org/compuscene/metrics/prometheus/PrometheusSettings.java
@@ -42,10 +42,6 @@ public class PrometheusSettings {
         STRICT_EXPAND_OPEN_HIDDEN,
         /** See {@link IndicesOptions#strictExpandOpenAndForbidClosed()}  */
         STRICT_EXPAND_OPEN_FORBID_CLOSED,
-        /**
-         * Note: There is a missing static method in the upstream (should be fixed in OpenSearch 3.6.0).
-         * Tracks <a href="https://github.com/opensearch-project/OpenSearch/issues/20963">OpenSearch issue #20963</a>.
-         */
         STRICT_EXPAND_OPEN_HIDDEN_FORBID_CLOSED,
         /** See {@link IndicesOptions#strictExpandOpenAndForbidClosedIgnoreThrottled()}  */
         STRICT_EXPAND_OPEN_FORBID_CLOSED_IGNORE_THROTTLED,
@@ -204,8 +200,7 @@ public class PrometheusSettings {
                 indicesOptions = IndicesOptions.strictExpandOpenAndForbidClosed();
                 break;
             case STRICT_EXPAND_OPEN_HIDDEN_FORBID_CLOSED:
-                //indicesOptions = IndicesOptions.strictExpandOpenHiddenAndForbidClosed(); // from OpenSearch 3.6.0
-                indicesOptions = IndicesOptions.STRICT_EXPAND_OPEN_HIDDEN_FORBID_CLOSED;
+                indicesOptions = IndicesOptions.strictExpandOpenHiddenAndForbidClosed();
                 break;
             case STRICT_EXPAND_OPEN_FORBID_CLOSED_IGNORE_THROTTLED:
                 indicesOptions = IndicesOptions.strictExpandOpenAndForbidClosedIgnoreThrottled();

--- a/src/test/java/org/opensearch/plugin/bwc/PluginBackwardsCompatibilityIT.java
+++ b/src/test/java/org/opensearch/plugin/bwc/PluginBackwardsCompatibilityIT.java
@@ -34,8 +34,8 @@ import java.util.stream.Collectors;
  */
 public class PluginBackwardsCompatibilityIT extends OpenSearchRestTestCase {
 
-    public static final Version BWCVersion = Version.V_3_5_0;
-    public static final Version NewVersion = Version.V_3_6_0;
+    public static final Version BWCVersion = Version.V_3_6_0;
+    public static final Version NewVersion = Version.V_3_7_0;
 
     private static final ClusterType CLUSTER_TYPE = ClusterType.parse(System.getProperty("tests.rest.bwcsuite"));
     private static final String CLUSTER_NAME = System.getProperty("tests.clustername");


### PR DESCRIPTION
### Description
Bumps the plugin to support OpenSearch 3.7.0.

- Update plugin version to `3.7.0.0` and opensearch_version to `3.7.0-SNAPSHOT`
- Update BWC versions to `3.6.0` / `3.6.0.0`
- Add `3.7.0` row to the compatibility matrix
- Replace the `IndicesOptions.STRICT_EXPAND_OPEN_HIDDEN_FORBID_CLOSED` workaround with the proper `IndicesOptions.strictExpandOpenHiddenAndForbidClosed()` static method call, which was added in OpenSearch 3.6.0 (opensearch-project/OpenSearch#20963)

### Related Issues
Related: #531

### Check List
- _[ ] New functionality includes testing._
- _[ ] New functionality has been documented._
- _[ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)._
- [x] Commits are signed per the DCO using `--signoff`.
- _[ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose)._

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/opensearch-prometheus-exporter/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).