### PR TITLE
add missing javadoc for enum entry

### DIFF
--- a/src/main/java/org/compuscene/metrics/prometheus/PrometheusSettings.java
+++ b/src/main/java/org/compuscene/metrics/prometheus/PrometheusSettings.java
@@ -42,6 +42,7 @@ public class PrometheusSettings {
         STRICT_EXPAND_OPEN_HIDDEN,
         /** See {@link IndicesOptions#strictExpandOpenAndForbidClosed()}  */
         STRICT_EXPAND_OPEN_FORBID_CLOSED,
+        /** See {@link IndicesOptions#strictExpandOpenHiddenAndForbidClosed()} */
         STRICT_EXPAND_OPEN_HIDDEN_FORBID_CLOSED,
         /** See {@link IndicesOptions#strictExpandOpenAndForbidClosedIgnoreThrottled()}  */
         STRICT_EXPAND_OPEN_FORBID_CLOSED_IGNORE_THROTTLED,


### PR DESCRIPTION
### Description
this caused a javadoc warning on build. this is a follow-up to commit 5f4e05b which removed the javadoc.

### Related Issues
follow-up to #533

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/opensearch-prometheus-exporter/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).